### PR TITLE
Dev Tools and Key Exchange Logic Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ SRC := \
     src/socket/socket.c \
     src/crypto/crypto.c \
     src/synack/tapin.c \
-	src/invite/invite.c
+	src/invite/invite.c \
+    src/common.c
 
 OBJ := $(SRC:.c=.o)
 
@@ -39,14 +40,14 @@ TEST_SRC := \
 
 TESTS := $(TEST_SRC:.c=)
 
-tests/test_invite: tests/test_invite.c src/socket/socket.c src/crypto/crypto.c src/invite/invite.c
+tests/test_invite: tests/test_invite.c src/socket/socket.c src/crypto/crypto.c src/invite/invite.c src/common.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-tests/test_crypto: tests/test_crypto.c src/socket/socket.c src/crypto/crypto.c src/invite/invite.c
+tests/test_crypto: tests/test_crypto.c src/socket/socket.c src/crypto/crypto.c src/invite/invite.c src/common.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # test_tapin requires tapin.c
-tests/test_tapin: tests/test_tapin.c src/socket/socket.c src/crypto/crypto.c src/invite/invite.c src/synack/tapin.c
+tests/test_tapin: tests/test_tapin.c src/socket/socket.c src/crypto/crypto.c src/invite/invite.c src/synack/tapin.c src/common.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 test: $(TESTS)

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include "common.h"
+
+int debug_enabled = 0;
+
+void debug_print(const char *fmt, ...) {
+    if (!debug_enabled) return;
+    va_list args;
+    va_start(args, fmt);
+    fprintf(stderr, "[DEBUG] ");
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+}

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,12 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <stdio.h>
+extern int debug_enabled;
+
+void debug_print(const char *fmt, ...);
+
+#define DEBUG_PRINT(...) \
+    do { if (debug_enabled) fprintf(stderr, __VA_ARGS__); } while (0)
+
+#endif

--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -14,16 +14,28 @@ int key_exchange(int sockfd, int initiator, keypair_t *local,
     unsigned char peer_pk[PUBKEY_LEN];
 
     if (initiator) {
+        // debug
+
+        printf("[*] Sending public key...\n");
         if (write_all(sockfd, local->pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
+
+
+        printf("[*] Waiting for peer public key...\n");
         if (read_all(sockfd, peer_pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
 
+        printf("[*] Deriving session keys (client)...\n");
         if (crypto_kx_client_session_keys(k_rx, k_tx, local->pk, local->sk, peer_pk) != 0)
             return -1;
 
     } else {
+
+        printf("[*] Waiting for initiator's public key...\n");
         if (read_all(sockfd, peer_pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
+
+        printf("[*] Sending own public key...\n");
         if (write_all(sockfd, local->pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
 
+        printf("[*] Deriving session keys (server)...\n");
         if (crypto_kx_server_session_keys(k_rx, k_tx, local->pk, local->sk, peer_pk) != 0)
             return -1;
 

--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -1,5 +1,6 @@
 #include "crypto.h"
 #include "socket/socket.h"
+#include "common.h"
 
 #include <sodium.h>
 #include <unistd.h>
@@ -16,26 +17,26 @@ int key_exchange(int sockfd, int initiator, keypair_t *local,
     if (initiator) {
         // debug
 
-        printf("[*] Sending public key...\n");
+        DEBUG_PRINT("[*] Sending public key...\n");
         if (write_all(sockfd, local->pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
 
 
-        printf("[*] Waiting for peer public key...\n");
+        DEBUG_PRINT("[*] Waiting for peer public key...\n");
         if (read_all(sockfd, peer_pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
 
-        printf("[*] Deriving session keys (client)...\n");
+        DEBUG_PRINT("[*] Deriving session keys (client)...\n");
         if (crypto_kx_client_session_keys(k_rx, k_tx, local->pk, local->sk, peer_pk) != 0)
             return -1;
 
     } else {
 
-        printf("[*] Waiting for initiator's public key...\n");
+        DEBUG_PRINT("[*] Waiting for initiator's public key...\n");
         if (read_all(sockfd, peer_pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
 
-        printf("[*] Sending own public key...\n");
+        DEBUG_PRINT("[*] Sending own public key...\n");
         if (write_all(sockfd, local->pk, PUBKEY_LEN) != PUBKEY_LEN) return -1;
 
-        printf("[*] Deriving session keys (server)...\n");
+        DEBUG_PRINT("[*] Deriving session keys (server)...\n");
         if (crypto_kx_server_session_keys(k_rx, k_tx, local->pk, local->sk, peer_pk) != 0)
             return -1;
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "crypto/crypto.h"
 #include "synack/tapin.h"
 #include "invite/invite.h"
+#include "common.h"
 
 #define NONCE_SIZE 24
 
@@ -69,11 +70,12 @@ int main(int argc, char *argv[]) {
         {"password", required_argument, 0, 'p'},
         {"rekey",    no_argument,       0, 'r'},
         {"help",     no_argument,       0, 'h'},
+        {"debug",    no_argument,       0, 'd'},
         {0, 0, 0, 0}
     };
 
     int option;
-    while ((option = getopt_long(argc, argv, "l:c:i:p:r", long_options, NULL)) != -1) {
+    while ((option = getopt_long(argc, argv, "l:c:i:p:r:h:d", long_options, NULL)) != -1) {
         switch (option) {
             case 'l':
                 listen_port = optarg;
@@ -101,7 +103,9 @@ int main(int argc, char *argv[]) {
             case 'h':
                 print_help();
                 exit(0);
-
+            case 'd':
+                debug_enabled = 1;
+                break;
             default: 
                 fprintf(stderr, "Usage: %s [--listen <port>] [--connect <host:port>] [--invite <code>] [--password <secret>] [--rekey] [--help]\n", argv[0]);
                 exit(1);
@@ -171,7 +175,7 @@ int main(int argc, char *argv[]) {
             char invite[INVITE_LEN];
             if (invite_generate(invite, sizeof invite, password, local_ip, listen_port) == 0) {
                 printf("Invite Code: %s\n", invite);
-                printf("Share with peer: --invite %s --password <secret>\n", invite);
+                printf("Share with peer: --invite %s --password %s\n", invite, password);
             } else {
                 fprintf(stderr, "Failed to generate invite code\n");
             }
@@ -315,7 +319,7 @@ static void *send_loop(void *arg) {
     }
 
     // debug
-    fprintf(stderr, "[-] Input closed or error occurred in send loop\n");
+    DEBUG_PRINT("[-] Input closed or error occurred in send loop\n");
 
 
     if (line) {

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,8 @@ typedef struct {
 static void *receive_loop(void *arg);
 static void *send_loop(void *arg);
 
+void print_help(void);
+
 int main(int argc, char *argv[]) {
     const char *listen_port = NULL;
     const char *connect_host = NULL;

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -105,7 +105,7 @@ ssize_t read_all(int fd, void *buf, size_t len) {
     } 
     
     if (poll_status == TIMEOUT) {
-      fprintf(stderr, "Connection timedout. Errno value: %d\n", errno);
+      fprintf(stderr, "Connection timed out. Errno value: %d\n", errno);
       return errno;
     }
     

--- a/src/synack/tapin.c
+++ b/src/synack/tapin.c
@@ -1,6 +1,6 @@
 #include "tapin.h"
 #include "crypto/crypto.h"
-
+#include "common.h"
 
 #include <stdio.h>
 
@@ -17,11 +17,11 @@ int tapped_in(int fd, int initiator,
     }
 
     //debug
-    printf("[*] Starting key exchange as %s\n", initiator ? "initiator" : "listener");
+    DEBUG_PRINT("[*] Starting key exchange as %s\n", initiator ? "initiator" : "listener");
 
 
     if (key_exchange(fd, initiator, &self, k_rx, k_tx) != 0) {
-        fprintf(stderr, "Key exchange has failed\n");
+        DEBUG_PRINT("Key exchange has failed\n");
         return -1;
     }
     return 0;

--- a/src/synack/tapin.c
+++ b/src/synack/tapin.c
@@ -11,10 +11,14 @@ int tapped_in(int fd, int initiator,
                 unsigned char k_tx[32]) {
     keypair_t self;
     generated_keypair(&self);
-    if (!invite_code || !password) {
+    if (initiator && (!invite_code || !password)) {
         fprintf(stderr, "invite code and password are required\n");
         return -1;
     }
+
+    //debug
+    printf("[*] Starting key exchange as %s\n", initiator ? "initiator" : "listener");
+
 
     if (key_exchange(fd, initiator, &self, k_rx, k_tx) != 0) {
         fprintf(stderr, "Key exchange has failed\n");


### PR DESCRIPTION
## Debug

A logic error enforced invite/password presence regardless of user role (initiator vs listener). Therefore, invite_code and password would be passed as NULL causing tapped_in() to return an error during handshake due to the missing parameters. The listener (—listen flag user) should not need to parse or verify invite codes — only the initiator (—invite flag user) does.

Terminal 1: ```./tapin --listen 5505 --password 123``` 
Result: ```invite code and password are required``` 

Terminal 2: ```tapin % ./tapin --invite <placeholder> --password 123```
Result: ```Key exchange has failed```

Key exchange failed due to restrictive password validation logic


## Patches


### Minor

- Declared print_help before main() in main.c to prevent build failures


### Context Improvement Check


Initiator was added as an optional chain
```
if (initiator && (!invite_code || !password)) {
    fprintf(stderr, "invite code and password are required\n");
    return -1;
}
```
- Now the listener can pass NULL for invite_code
- Now only the initiator is required provide a valid invite and password.


### Added ```used_invite``` Controller in Main.c

- Prevents listeners from passing invite_code and password into tapped_in when they shouldn’t be.
- Ensures Initiators send invite_code and password when --invite is invoked


### Debug Flag to Toggle Logging

- Created a very lightweight wrapper from the print statement used to pinpoint the logic bug above
- Replaced noisy logs with optional logs using expandable function for more detailed logging in the future
- New CLI Flag: “--debug” or “-d”
- Updated make file to properly compile common.c 

### All Test Cases Pass After Final Changes
