### PR TITLE
Fix Sprintf

### DIFF
--- a/src/lib/colorize/colorize.c
+++ b/src/lib/colorize/colorize.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-
+#define MAX_INPUT_LEN 256
 // All colors are bright.
 // \033[ is the escape sequence to set the color.
 // The color settings are separated by semicolon(;)
@@ -39,6 +39,11 @@ Flushing stream manually for two reasons:
 */
 void print_with_colors(FILE *output_stream, char *color, char *input) {
   if (!valid_color(color)) {
+    return;
+  }
+
+  if (strlen(input) > MAX_INPUT_LEN - 2) {
+    printf("Input too large. Consider shortening to a length <= 254 chars.;");
     return;
   }
   fprintf(output_stream, "%s%s%s", color, input, RESET);

--- a/src/lib/colorize/colorize.c
+++ b/src/lib/colorize/colorize.c
@@ -42,8 +42,8 @@ void print_with_colors(FILE *output_stream, char *color, char *input) {
     return;
   }
 
-  if (strlen(input) > MAX_INPUT_LEN - 2) {
-    printf("Input too large. Consider shortening to a length <= 254 chars.;");
+  if (strlen(input) > MAX_INPUT_LEN) {
+    printf("Input too large. Consider shortening to a length <= 256 chars.;");
     return;
   }
   fprintf(output_stream, "%s%s%s", color, input, RESET);

--- a/tests/test_colorize.c
+++ b/tests/test_colorize.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include <lib/colorize/colorize.h>
+#include <colorize.h>
 #include "test_helpers.h"
 #include <stdlib.h>
 

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -12,10 +12,10 @@ void assert_status(int expression, char *template_string) {
 
   char formatted_output[256];
   if (expression) {
-    snprintf(formatted_output, "%s passed.\n", template_string);
+    snprintf(formatted_output, 256, "%s passed.\n", template_string);
     print_with_colors(stdout, GREEN, formatted_output);
   } else {
-    snprintf(formatted_output, "%s failed.\n", template_string);
+    snprintf(formatted_output, 256, "%s failed.\n", template_string);
     print_with_colors(stderr, RED, formatted_output);
     exit(1);
   }

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -1,21 +1,22 @@
-#include <lib/colorize/colorize.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <colorize.h>
+#define MAX_INPUT_LEN 256
 
 void assert_status(int expression, char *template_string) {
-  int strlen = sizeof(template_string) / sizeof(template_string[0]);
   // Account for null terminator (2 chars) and passed|failed (6)
-  if (strlen > 248) {
+  if (strlen(template_string) > MAX_INPUT_LEN - 10) {
     printf("Input too large. Consider shortening to a length <= 248 chars.;");
     return;
   }
 
-  char formatted_output[256];
+  char formatted_output[MAX_INPUT_LEN];
   if (expression) {
-    snprintf(formatted_output, 256, "%s passed.\n", template_string);
+    snprintf(formatted_output, MAX_INPUT_LEN, "%s passed.\n", template_string);
     print_with_colors(stdout, GREEN, formatted_output);
   } else {
-    snprintf(formatted_output, 256, "%s failed.\n", template_string);
+    snprintf(formatted_output, MAX_INPUT_LEN, "%s failed.\n", template_string);
     print_with_colors(stderr, RED, formatted_output);
     exit(1);
   }

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -7,7 +7,7 @@
 void assert_status(int expression, char *template_string) {
   // Account for null terminator (2 chars) and passed|failed (6)
   if (strlen(template_string) > MAX_INPUT_LEN - 10) {
-    printf("Input too large. Consider shortening to a length <= 248 chars.;");
+    printf("Input too large. Consider shortening to a length <= 246 chars.;");
     return;
   }
 

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -7,7 +7,7 @@
 void assert_status(int expression, char *template_string) {
   // Account for null terminator (2 chars) and passed|failed (6)
   if (strlen(template_string) > MAX_INPUT_LEN - 10) {
-    printf("Input too large. Consider shortening to a length <= 246 chars.;");
+    printf("Input too large. Consider shortening to a length <= 246 chars.");
     return;
   }
 

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -1,7 +1,7 @@
+#include <colorize.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <colorize.h>
 #define MAX_INPUT_LEN 256
 
 void assert_status(int expression, char *template_string) {

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -3,12 +3,19 @@
 #include <stdlib.h>
 
 void assert_status(int expression, char *template_string) {
+  int strlen = sizeof(template_string) / sizeof(template_string[0]);
+  // Account for null terminator (2 chars) and passed|failed (6)
+  if (strlen > 248) {
+    printf("Input too large. Consider shortening to a length <= 248 chars.;");
+    return;
+  }
+
   char formatted_output[256];
   if (expression) {
-    sprintf(formatted_output, "%s passed.\n", template_string);
+    snprintf(formatted_output, "%s passed.\n", template_string);
     print_with_colors(stdout, GREEN, formatted_output);
   } else {
-    sprintf(formatted_output, "%s failed.\n", template_string);
+    snprintf(formatted_output, "%s failed.\n", template_string);
     print_with_colors(stderr, RED, formatted_output);
     exit(1);
   }

--- a/tests/test_runner.bash
+++ b/tests/test_runner.bash
@@ -2,7 +2,7 @@
 
 # Ignore the src/main.c file
 LINKER_FILES=$(find src -name "*.c" ! -name "main.c")
-CFLAGS="-Wall -O2 -g -std=c11 -Isrc"
+CFLAGS="-Wall -O2 -g -std=c11 -Isrc -I src/lib/colorize"
 LDFLAGS="-lsodium -lpthread"
 
 # For this to work it needs to be a .c file

--- a/tests/test_runner.bash
+++ b/tests/test_runner.bash
@@ -2,7 +2,7 @@
 
 # Ignore the src/main.c file
 LINKER_FILES=$(find src -name "*.c" ! -name "main.c")
-CFLAGS="-Wall -O2 -g -std=c11 -Isrc -I src/lib/colorize"
+CFLAGS="-Wall -O2 -g -std=c11 -I src -I src/lib/colorize"
 LDFLAGS="-lsodium -lpthread"
 
 # For this to work it needs to be a .c file


### PR DESCRIPTION
I added in `sprintf `to format some output in the `test_helpers.c` but that was unsafe. So adding in a max buffer length, and using `snprintf`. This should protect us from buffer overflow errors (or attacks) when colorizing input.

This also puts max size for the `print_with_colors` function to 256 characters.

[Fixes this issue.](https://github.com/SysHarmonics/TapIn/issues/10)